### PR TITLE
[RFR] Cookie-based token storage (without DB)

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -31,7 +31,7 @@ module.exports = {
             },
             port: apiPort,
             security: {
-                expirationTokenDelay: 1800,
+                expirationTokenDelay: 1800, // in seconds
                 bcrypt: {
                     salt_work_factor: 10, // higher is safer, but slower
                 },

--- a/config/default.js
+++ b/config/default.js
@@ -22,15 +22,23 @@ module.exports = {
                 app: {Console: { timestamp: true, colorize: true, level: 'error' }},
                 http: {},
             },
-            maxAge: 600,
+            cookies: {
+                secure: false,
+                secureProxy: false,
+                httpOnly: false,
+                signed: false,
+                overwrite: true,
+            },
             port: apiPort,
             security: {
+                expirationTokenDelay: 1800,
                 bcrypt: {
                     salt_work_factor: 10, // higher is safer, but slower
                 },
                 jwt: {
                     privateKey: 'MY-VERY-PRIVATE-KEY',
                 },
+                secret: 'MY-VERY-SECRET-CRYPTO-KEY-DIFFERENT-FROM-JWT',
                 xdomain: {
                     master: {
                         base_url: frontendUrl,

--- a/e2e/lib/fixturesLoader.js
+++ b/e2e/lib/fixturesLoader.js
@@ -2,6 +2,7 @@ import config from 'config';
 import jwt from 'jsonwebtoken';
 import faker from 'faker';
 import uuid from 'uuid';
+import crypto from 'crypto';
 
 import data from '../fixtures/demo_fixtures.json';
 import productFactory from '../../src/api/products/productModel';
@@ -30,6 +31,14 @@ export default function(client) {
         return jwt.sign(user, config.apps.api.security.jwt.privateKey);
     }
 
+    function* getCookieTokenFor(email) {
+        let token = yield getTokenFor(email);
+
+        return crypto.createHmac('sha256', config.apps.api.security.secret)
+            .update(token)
+            .digest('hex');
+    }
+
     function* addProduct(productData) {
         // const causes an error! don't know why
         let defaultProductData = {
@@ -51,6 +60,7 @@ export default function(client) {
         loadDefaultFixtures,
         removeAllFixtures,
         getTokenFor,
+        getCookieTokenFor,
         addProduct,
     };
 }

--- a/e2e/lib/request.js
+++ b/e2e/lib/request.js
@@ -2,15 +2,26 @@ import http from 'http';
 import request from 'request';
 import app from '../../src/api/server';
 
-export default function myRequest(params, authToken = null) {
+export default function myRequest(params, authToken = null, cookies = {}) {
     return (callback) => {
         const port = process.env.NODE_PORT || 3010;
+        const baseUrl = `http://localhost:${port}`;
         const server = http.createServer(app.callback()).listen(port);
+        const jar = request.jar();
+
+        if (cookies) {
+            Object.keys(cookies).forEach(key => {
+                const cookie = request.cookie(`${key}=${cookies[key]}`);
+                jar.setCookie(cookie, baseUrl);
+            });
+        }
+
         const baseRequest = request.defaults({
-            baseUrl: `http://localhost:${port}`,
+            baseUrl,
             gzip: true,
             json: true,
             headers: authToken ? { authorization: `${authToken}` } : {},
+            jar,
         });
 
         baseRequest(params, (error, response) => {

--- a/makefile
+++ b/makefile
@@ -117,14 +117,14 @@ test-isomorphic-unit:
 	@NODE_ENV=test ./node_modules/.bin/mocha --compilers="js:babel-core/register" --recursive ./src/isomorphic/{,**/}*.spec.js
 
 test-frontend-functional: reset-test-database
-	make load-fixtures
+	NODE_ENV=test make load-fixtures
 	@make build-test
 	@node_modules/.bin/pm2 start ./config/pm2_servers/test.json
 	@node_modules/.bin/nightwatch --config="./e2e/frontend/nightwatch.json"
 	@node_modules/.bin/pm2 delete ./config/pm2_servers/test.json
 
 load-fixtures:
-	@NODE_ENV=test ./node_modules/.bin/babel-node ./bin/loadFixtures.js
+	@./node_modules/.bin/babel-node ./bin/loadFixtures.js
 
 test:
 	@cp -n ./config/test-dist.js ./config/test.js | true

--- a/src/admin/js/login.js
+++ b/src/admin/js/login.js
@@ -1,3 +1,4 @@
+/* globals ADMIN_API_URL */
 function redirect() {
     window.location = '/admin';
 }
@@ -16,7 +17,8 @@ document.getElementById('loginForm').addEventListener('submit', (event) => {
     event.preventDefault(); // stop form from submitting
 
     const req = new XMLHttpRequest();
-    req.open('POST', `${ADMIN_API_URL}authenticate`, true); // eslint-disable-line no-undef
+    req.withCredentials = true;
+    req.open('POST', `${ADMIN_API_URL}authenticate`, true);
     req.setRequestHeader('Content-Type', 'application/json');
 
     req.onload = () => {

--- a/src/admin/js/login.js
+++ b/src/admin/js/login.js
@@ -4,7 +4,7 @@ function redirect() {
 }
 
 // check for user already logged in
-if (window.sessionStorage.getItem('token')) {
+if (window.localStorage.getItem('token')) {
     redirect();
 }
 
@@ -34,9 +34,10 @@ document.getElementById('loginForm').addEventListener('submit', (event) => {
             return showError();
         }
 
-        window.sessionStorage.setItem('id', json.id);
-        window.sessionStorage.setItem('email', json.email);
-        window.sessionStorage.setItem('token', json.token);
+        window.localStorage.setItem('id', json.id);
+        window.localStorage.setItem('email', json.email);
+        window.localStorage.setItem('token', json.token);
+        window.localStorage.setItem('expires', json.expires);
         redirect();
     };
     req.onerror = showError;

--- a/src/admin/js/main.js
+++ b/src/admin/js/main.js
@@ -42,6 +42,7 @@ myApp.config(['NgAdminConfigurationProvider', (nga) => {
 }]);
 
 myApp.config(['RestangularProvider', (RestangularProvider) => {
+    RestangularProvider.setDefaultHttpFields({ withCredentials: true });
     RestangularProvider.addFullRequestInterceptor((element, operation, what, url, headers, params) => {
         headers = headers || {};
         headers['Authorization'] = window.sessionStorage.getItem('token');

--- a/src/admin/js/main.js
+++ b/src/admin/js/main.js
@@ -7,15 +7,16 @@ function redirectToLogin() {
 }
 
 function logout() {
-    window.sessionStorage.removeItem('id');
-    window.sessionStorage.removeItem('email');
-    window.sessionStorage.removeItem('token');
+    window.localStorage.removeItem('id');
+    window.localStorage.removeItem('email');
+    window.localStorage.removeItem('token');
+    window.localStorage.removeItem('expires');
     redirectToLogin();
 }
 
 window.logout = logout;
 
-if (!window.sessionStorage.getItem('token')) redirectToLogin();
+if (!window.localStorage.getItem('token')) redirectToLogin();
 
 const myApp = angular.module('myApp', ['ng-admin']);
 
@@ -44,8 +45,16 @@ myApp.config(['NgAdminConfigurationProvider', (nga) => {
 myApp.config(['RestangularProvider', (RestangularProvider) => {
     RestangularProvider.setDefaultHttpFields({ withCredentials: true });
     RestangularProvider.addFullRequestInterceptor((element, operation, what, url, headers, params) => {
+        const currentTime = (new Date()).getTime();
+        const tokenExpires = window.localStorage.getItem('expires');
+
+        if (tokenExpires && tokenExpires < currentTime) {
+            logout();
+            redirectToLogin();
+        }
+
         headers = headers || {};
-        headers['Authorization'] = window.sessionStorage.getItem('token');
+        headers['Authorization'] = window.localStorage.getItem('token');
 
         if (operation === 'getList') {
             if (params._page) {

--- a/src/api/authentication/authenticateAdminRoutes.js
+++ b/src/api/authentication/authenticateAdminRoutes.js
@@ -25,15 +25,19 @@ app.use(koaRoute.post('/', function* login() {
     const cookieToken = crypto.createHmac('sha256', config.apps.api.security.secret)
         .update(token)
         .digest('hex');
+    const delay = config.apps.api.security.expirationTokenDelay * 1000;
+    const tokenExpires = (new Date((new Date()).getTime() + delay));
 
     this.cookies.set('token', cookieToken, {
         ...config.apps.api.cookies,
+        expires: tokenExpires,
         httpOnly: true,
     });
 
     this.body = {
         id: user.id,
         email: user.email,
+        expires: tokenExpires.getTime(),
         token,
     };
 }));

--- a/src/api/authentication/authenticateAdminRoutes.js
+++ b/src/api/authentication/authenticateAdminRoutes.js
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import coBody from 'co-body';
 import config from 'config';
 import jwt from 'jsonwebtoken';
@@ -20,10 +21,20 @@ app.use(koaRoute.post('/', function* login() {
         this.throw('Invalid credentials.', 401);
     }
 
+    const token = jwt.sign(user, config.apps.api.security.jwt.privateKey);
+    const cookieToken = crypto.createHmac('sha256', config.apps.api.security.secret)
+        .update(token)
+        .digest('hex');
+
+    this.cookies.set('token', cookieToken, {
+        ...config.apps.api.cookies,
+        httpOnly: true,
+    });
+
     this.body = {
         id: user.id,
         email: user.email,
-        token: jwt.sign(user, config.apps.api.security.jwt.privateKey),
+        token,
     };
 }));
 

--- a/src/api/authentication/authenticateApiRoutes.js
+++ b/src/api/authentication/authenticateApiRoutes.js
@@ -29,15 +29,19 @@ app.use(koaRoute.post('/sign-in', function* signIn() {
     const cookieToken = crypto.createHmac('sha256', config.apps.api.security.secret)
         .update(token)
         .digest('hex');
+    const delay = config.apps.api.security.expirationTokenDelay * 1000;
+    const tokenExpires = (new Date((new Date()).getTime() + delay));
 
     this.cookies.set('token', cookieToken, {
         ...config.apps.api.cookies,
+        expires: tokenExpires,
         httpOnly: true,
     });
 
     this.body = {
         id: user.id,
         email: user.email,
+        expires: tokenExpires.getTime(),
         token,
     };
 }));

--- a/src/api/authentication/authenticateApiRoutes.js
+++ b/src/api/authentication/authenticateApiRoutes.js
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import coBody from 'co-body';
 import config from 'config';
 import jwt from 'jsonwebtoken';
@@ -24,10 +25,20 @@ app.use(koaRoute.post('/sign-in', function* signIn() {
         this.throw('Invalid credentials.', 401);
     }
 
+    const token = jwt.sign(user, config.apps.api.security.jwt.privateKey);
+    const cookieToken = crypto.createHmac('sha256', config.apps.api.security.secret)
+        .update(token)
+        .digest('hex');
+
+    this.cookies.set('token', cookieToken, {
+        ...config.apps.api.cookies,
+        httpOnly: true,
+    });
+
     this.body = {
         id: user.id,
         email: user.email,
-        token: jwt.sign(user, config.apps.api.security.jwt.privateKey),
+        token,
     };
 }));
 

--- a/src/api/lib/middlewares/tokenChecker.js
+++ b/src/api/lib/middlewares/tokenChecker.js
@@ -1,8 +1,18 @@
+import crypto from 'crypto';
 import config from 'config';
 import jwt from 'jsonwebtoken';
 
 export default function* (next) {
     const token = this.get('Authorization');
+    const cookieToken = this.cookies.get('token');
+    const expectedCookieToken = crypto.createHmac('sha256', config.apps.api.security.secret)
+        .update(token)
+        .digest('hex');
+
+    if (cookieToken !== expectedCookieToken) {
+        this.status = 401;
+        return;
+    }
 
     try {
         this.user = yield jwt.verify(token, config.apps.api.security.jwt.privateKey);

--- a/src/frontend/js/app/App.js
+++ b/src/frontend/js/app/App.js
@@ -6,6 +6,15 @@ import HelmetTitle from './HelmetTitle';
 import { signOut as signOutActions } from '../user/userActions';
 
 export class App extends Component {
+    componentWillReceiveProps(nextProps) {
+        const { user, signOut } = nextProps;
+        const currentTime = (new Date()).getTime();
+
+        if (user.token && user.expires && user.expires < currentTime) {
+            signOut();
+        }
+    }
+
     render() {
         const { user, signOut } = this.props;
 

--- a/src/frontend/js/app/entities/fetchEntities.js
+++ b/src/frontend/js/app/entities/fetchEntities.js
@@ -11,6 +11,9 @@ export const fetchEntitiesFactory = path => jwt => {
 
     return fetch(`${API_URL}/${path}`, {
         headers,
+        // Allows API to set http-only cookies with AJAX calls
+        // @see http://www.redotheweb.com/2015/11/09/api-security.html
+        credentials: 'include',
     })
     .then(response => {
         if (!response.ok) {
@@ -38,6 +41,9 @@ export const fetchEntityFactory = path => (id, jwt) => {
 
     return fetch(`${API_URL}/${path}/${id}`, {
         headers,
+        // Allows API to set http-only cookies with AJAX calls
+        // @see http://www.redotheweb.com/2015/11/09/api-security.html
+        credentials: 'include',
     })
     .then(response => {
         if (!response.ok) {

--- a/src/frontend/js/app/reducers.js
+++ b/src/frontend/js/app/reducers.js
@@ -8,7 +8,7 @@ import { reducer as form } from 'redux-form';
 const rootReducer = combineReducers({
     form,
     routing: routeReducer,
-    user: userReducerFactory(window.sessionStorage),
+    user: userReducerFactory(window.localStorage),
     order,
     product,
 });

--- a/src/frontend/js/user/userApi.js
+++ b/src/frontend/js/user/userApi.js
@@ -10,6 +10,9 @@ export function fetchSignIn(email, password) {
             email,
             password,
         }),
+        // Allows API to set http-only cookies with AJAX calls
+        // @see http://www.redotheweb.com/2015/11/09/api-security.html
+        credentials: 'include',
     })
     .then(response => {
         if (!response.ok) {

--- a/src/frontend/js/user/userApi.js
+++ b/src/frontend/js/user/userApi.js
@@ -39,6 +39,9 @@ export function fetchSignUp(email, password) {
             email,
             password,
         }),
+        // Allows API to set http-only cookies with AJAX calls
+        // @see http://www.redotheweb.com/2015/11/09/api-security.html
+        credentials: 'include',
     })
     .then(response => {
         if (!response.ok) {
@@ -54,14 +57,16 @@ export function fetchSignUp(email, password) {
     }));
 }
 
-export const storeLocalUser = ({ id, email, token }) => {
-    sessionStorage.setItem('id', id);
-    sessionStorage.setItem('email', email);
-    sessionStorage.setItem('token', token);
+export const storeLocalUser = ({ id, email, token, expires }) => {
+    localStorage.setItem('id', id);
+    localStorage.setItem('email', email);
+    localStorage.setItem('token', token);
+    localStorage.setItem('expires', expires);
 };
 
 export const removeLocalUser = () => {
-    sessionStorage.removeItem('id');
-    sessionStorage.removeItem('email');
-    sessionStorage.removeItem('token');
+    localStorage.removeItem('id');
+    localStorage.removeItem('email');
+    localStorage.removeItem('token');
+    localStorage.removeItem('expires');
 };

--- a/src/frontend/js/user/userReducer.js
+++ b/src/frontend/js/user/userReducer.js
@@ -1,11 +1,12 @@
 import { userActionTypes } from './userActions';
 
-export default function(sessionStorage) {
+export default function(localStorage) {
     const initialState = {
-        id: sessionStorage.getItem('id'),
-        email: sessionStorage.getItem('email'),
-        token: sessionStorage.getItem('token'),
-        authenticated: !!sessionStorage.getItem('token'),
+        id: localStorage.getItem('id'),
+        email: localStorage.getItem('email'),
+        token: localStorage.getItem('token'),
+        expires: localStorage.getItem('expires'),
+        authenticated: !!localStorage.getItem('token') && localStorage.getItem('expires') > (new Date()).getTime(),
         loading: false,
     };
 
@@ -39,6 +40,7 @@ export default function(sessionStorage) {
                 id: null,
                 loading: false,
                 token: null,
+                expires: null,
             };
 
         case userActionTypes.signOut.SUCCESS:
@@ -49,6 +51,7 @@ export default function(sessionStorage) {
                 id: null,
                 loading: false,
                 token: null,
+                expires: null,
             };
         default:
             return state;

--- a/src/frontend/js/user/userReducer.spec.js
+++ b/src/frontend/js/user/userReducer.spec.js
@@ -5,16 +5,18 @@ import { signIn, signOut, signUp } from './userActions';
 
 describe('user reducer', () => {
     const getItemWithUser = sinon.stub();
+    const expireTokenTime = (new Date()).getTime() + 30 * 1000;
     getItemWithUser.withArgs('id').returns('foo');
     getItemWithUser.withArgs('email').returns('foo@bar.com');
     getItemWithUser.withArgs('token').returns('bar');
+    getItemWithUser.withArgs('expires').returns(expireTokenTime);
 
-    const sessionStorageWithUser = {
+    const localStorageWithUser = {
         getItem: getItemWithUser,
     };
 
-    it('should return the user saved in sessionStorage as its initial state', () => {
-        const reducer = reducerFactory(sessionStorageWithUser);
+    it('should return the user saved in localStorage as its initial state', () => {
+        const reducer = reducerFactory(localStorageWithUser);
 
         expect(reducer(undefined, { type: 'foo' })).to.deep.equal({
             authenticated: true,
@@ -22,20 +24,22 @@ describe('user reducer', () => {
             id: 'foo',
             loading: false,
             token: 'bar',
+            expires: expireTokenTime,
         });
     });
 
     it('should handle the signIn.success action', () => {
         const getItem = sinon.stub().returns(undefined);
-        const sessionStorage = {
+        const localStorage = {
             getItem,
         };
-        const reducer = reducerFactory(sessionStorage);
+        const reducer = reducerFactory(localStorage);
 
         expect(reducer(undefined, signIn.success({
             email: 'foo@bar.com',
             id: 'foo',
             token: 'bar',
+            expires: expireTokenTime,
         }))).to.deep.equal({
             authenticated: true,
             error: false,
@@ -43,20 +47,22 @@ describe('user reducer', () => {
             email: 'foo@bar.com',
             loading: false,
             token: 'bar',
+            expires: expireTokenTime,
         });
     });
 
     it('should handle the signIn.failure action', () => {
         const getItem = sinon.stub().returns(undefined);
-        const sessionStorage = {
+        const localStorage = {
             getItem,
         };
-        const reducer = reducerFactory(sessionStorage);
+        const reducer = reducerFactory(localStorage);
         const error = new Error('Run you fools!');
         expect(reducer(undefined, signIn.failure(error))).to.deep.equal({
             id: null,
             email: null,
             token: null,
+            expires: null,
             authenticated: false,
             loading: false,
             error,
@@ -65,15 +71,16 @@ describe('user reducer', () => {
 
     it('should handle the signUp.success action', () => {
         const getItem = sinon.stub().returns(undefined);
-        const sessionStorage = {
+        const localStorage = {
             getItem,
         };
-        const reducer = reducerFactory(sessionStorage);
+        const reducer = reducerFactory(localStorage);
 
         expect(reducer(undefined, signUp.success({
             email: 'foo@bar.com',
             id: 'foo',
             token: 'bar',
+            expires: expireTokenTime,
         }))).to.deep.equal({
             authenticated: true,
             error: false,
@@ -81,20 +88,22 @@ describe('user reducer', () => {
             email: 'foo@bar.com',
             loading: false,
             token: 'bar',
+            expires: expireTokenTime,
         });
     });
 
     it('should handle the signUp.failure action', () => {
         const getItem = sinon.stub().returns(undefined);
-        const sessionStorage = {
+        const localStorage = {
             getItem,
         };
-        const reducer = reducerFactory(sessionStorage);
+        const reducer = reducerFactory(localStorage);
         const error = new Error('Run you fools!');
         expect(reducer(undefined, signUp.failure(error))).to.deep.equal({
             id: null,
             email: null,
             token: null,
+            expires: null,
             authenticated: false,
             loading: false,
             error,
@@ -102,7 +111,7 @@ describe('user reducer', () => {
     });
 
     it('should handle the signOut.success action', () => {
-        const reducer = reducerFactory(sessionStorageWithUser);
+        const reducer = reducerFactory(localStorageWithUser);
 
         expect(reducer(undefined, signOut.success())).to.deep.equal({
             authenticated: false,
@@ -110,6 +119,7 @@ describe('user reducer', () => {
             email: null,
             loading: false,
             token: null,
+            expires: null,
         });
     });
 });


### PR DESCRIPTION
In order to avoid XSS and CSRF attack, we need to store
a unique session ID in a http-only cookie.
For more details, see
http://www.redotheweb.com/2015/11/09/api-security.html

The only difference with the specified method is that
we do not have a DB table to store the unique session ID.
Instead, we encrypt the JWT token with a new secret key
and store it in the cookie.
This way, at each API call, we can crypt again the specified JWT
and check wether it corresponds to the cookie token.
Since the JWT is deleted at end of the session, so is the cookie token.

## TODO
- [x] Cookie-based token storage
- [x] Use localStorage instead of sessionStorage
- [x] localStorage token and cookie token expiration

## Preview

![payload](https://sc-cdn.scaleengine.net/i/7a0de8ecae646dcd721fd8ffafc30764.png)

![cookie](https://sc-cdn.scaleengine.net/i/918cfa98a3e4eeeea64ca02f603d1740.png)