### PR TITLE
[RFR] Reasonable rate limiting

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -51,7 +51,16 @@ module.exports = {
                 jwt: {
                     privateKey: 'MY-VERY-PRIVATE-KEY',
                 },
-                rateLimitOptions: {},
+                rateLimitOptions: {
+                    auth: {
+                        duration: 60000,
+                        max: 5,
+                    },
+                    api: {
+                        duration: 3600000,
+                        max: 2500,
+                    },
+                },
                 secret: 'MY-VERY-SECRET-CRYPTO-KEY-DIFFERENT-FROM-JWT',
                 xdomain: {
                     master: {

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -11,8 +11,8 @@ import orderAdminApiRoutes from './orders/orderAdminApiRoutes';
 
 const app = koa();
 
-app.use(rateLimiterMiddleware(config.apps.api.security.rateLimitOptions));
 app.use(koaMount('/authenticate', authenticateAdminRoutes));
+app.use(rateLimiterMiddleware(config.apps.api.security.rateLimitOptions.api));
 app.use(tokenCheckerMiddleware);
 
 app.use(koaMount('/products', productAdminApiRoutes));

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -2,17 +2,19 @@ import config from 'config';
 import koa from 'koa';
 import koaMount from 'koa-mount';
 import koaRoute from 'koa-route';
-import rateLimiterMiddleware from './lib/rateLimiter';
 
 import authenticateApiRoutes from './authentication/authenticateApiRoutes';
 import methodFilter from './lib/middlewares/methodFilter';
 import orderApiRoutes from './orders/orderApiRoutes';
 import productApiRoutes from './products/productApiRoutes';
+import rateLimiterMiddleware from './lib/rateLimiter';
+
 
 const app = koa();
 
-app.use(rateLimiterMiddleware(config.apps.api.security.rateLimitOptions));
 app.use(koaMount('/', authenticateApiRoutes));
+
+app.use(rateLimiterMiddleware(config.apps.api.security.rateLimitOptions.api));
 app.use(koaMount('/products', productApiRoutes));
 app.use(koaMount('/orders', orderApiRoutes));
 

--- a/src/api/authentication/authenticateAdminRoutes.js
+++ b/src/api/authentication/authenticateAdminRoutes.js
@@ -11,7 +11,7 @@ import userRepositoryFactory from '../users/userModel';
 const app = koa();
 
 app.use(methodFilter(['POST']));
-app.use(koaRoute.post('/', rateLimiter(config.apps.api.security.rateLimitOptions)));
+app.use(koaRoute.post('/', rateLimiter(config.apps.api.security.rateLimitOptions.auth)));
 
 app.use(koaRoute.post('/', function* login() {
     const { email, password } = yield coBody(this);

--- a/src/api/authentication/authenticateApiRoutes.js
+++ b/src/api/authentication/authenticateApiRoutes.js
@@ -1,13 +1,16 @@
-import crypto from 'crypto';
 import coBody from 'co-body';
 import config from 'config';
+import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import koa from 'koa';
 import koaRoute from 'koa-route';
+import rateLimiterMiddleware from '../lib/rateLimiter';
 import userRepositoryFactory from '../users/userModel';
 
 const app = koa();
 let userRepository;
+
+app.use(koaRoute.post('/', rateLimiterMiddleware(config.apps.api.security.rateLimitOptions.auth)));
 
 app.use(function* init(next) {
     userRepository = userRepositoryFactory(this.client);


### PR DESCRIPTION
- [x] Differentiate rate limiting options for auth and for api
- [x] Use the same defaults as [node-ratelimiter](https://github.com/marmelab/node-ratelimiter) for api rate limiting