### PR TITLE
[RFR] Signature of the withFetchingOnMount HOC

### DIFF
--- a/src/common-client/fetch/README.md
+++ b/src/common-client/fetch/README.md
@@ -55,11 +55,11 @@ export default entityFactory(productActionTypes, productActions, fetchFactory('p
 We defined two sagas here: one will handle the `item` actions, the other the `list` actions.
 
 Whenever the `productActions.item.request` is dispatched, a saga will run and will dispatch:
-- the `productActions.item.success` action with the fetched product if successull
+- the `productActions.item.success` action with the fetched product if successfull
 - the `productActions.item.failure` action with the error if failed.
 
 Whenever the `productActions.list.request` is dispatched, a saga will run and will dispatch:
-- the `productActions.list.success` action with the fetched products if successull
+- the `productActions.list.success` action with the fetched products if successfull
 - the `productActions.list.failure` action with the error if failed.
 
 Then, we need a reducer for our store:
@@ -151,7 +151,7 @@ const mapStateToProps = state => ({ products: state.product.list });
 const mapDispatchToProps = ({ orderProduct: addProductToShoppingCart });
 
 export default compose(
-    withFetchingOnMount(productActions.list.request, { data: dataSelector, loading: loadingSelector }),
+    withFetchingOnMount(productActions.list.request, { dataSelector, loadingSelector }),
     connect(mapStateToProps, mapDispatchToProps)
 )(ProductList);
 ```

--- a/src/common-client/fetch/README.md
+++ b/src/common-client/fetch/README.md
@@ -151,7 +151,7 @@ const mapStateToProps = state => ({ products: state.product.list });
 const mapDispatchToProps = ({ orderProduct: addProductToShoppingCart });
 
 export default compose(
-    withFetchingOnMount(productActions.list.request, dataSelector, null, loadingSelector),
+    withFetchingOnMount(productActions.list.request, { data: dataSelector, loading: loadingSelector }),
     connect(mapStateToProps, mapDispatchToProps)
 )(ProductList);
 ```

--- a/src/common-client/fetch/withFetchingOnMount.js
+++ b/src/common-client/fetch/withFetchingOnMount.js
@@ -33,30 +33,32 @@ export const DefaultLoading = () => (
  *
  * @param actionCreator An action creator
  * @param {Object} selectors The selectors used for data, loading and fetch parameters retrieval from state.
- * @param {dataSelector} selectors.data Mandatory selector to retrieve the fetched data from state.
- * @param {loadingSelector} selectors.loading Mandatory selector to retrieve the loading status from state.
- * @param {paramsSelector} selectors.params Optional selector to retrieve the parameters to use for fetch, from state.
+ * @param {dataSelector} selectors.dataSelector Mandatory selector to retrieve the fetched data from state.
+ * @param {loadingSelector} selectors.loadingSelector Mandatory selector to retrieve the loading status from state.
+ * @param {paramsSelector} selectors.paramsSelector Optional selector to retrieve the parameters to use for fetch, from state.
  * @param {Object} LoadingComponent The component to display when loading.
  */
 export default (actionCreator, selectors: {}, LoadingComponent = DefaultLoading) => BaseComponent => {
     if (!selectors) {
         console.error(`withFetchingOnMount(${BaseComponent.displayName}) requires at least two selectors, one to retrieve the fetched data and the other to retrieve the loading state.`); // eslint-disable-line max-len, no-console
         if (process.env.NODE_ENV !== 'production') {
-            console.log('Pass them withing an object as the second parameter of the withFetchingOnMount call like: `withFetchingOnMount(actionCreator, { data: dataSelector, loading: loadingSelector })`'); // eslint-disable-line max-len, no-console
+            console.log('Pass them withing an object as the second parameter of the withFetchingOnMount call like: `withFetchingOnMount(actionCreator, { dataSelector, loadingSelector })`'); // eslint-disable-line max-len, no-console
         }
     }
 
-    if (!selectors.data) {
+    const { dataSelector, loadingSelector, paramsSelector } = selectors;
+
+    if (!dataSelector) {
         console.error(`withFetchingOnMount(${BaseComponent.displayName}) requires the data selector, which retrieve the fetched data from state.`); // eslint-disable-line max-len, no-console
         if (process.env.NODE_ENV !== 'production') {
-            console.log('Pass it withing an object as the second parameter of the withFetchingOnMount call like: `withFetchingOnMount(actionCreator, { data: dataSelector, loading: loadingSelector })`'); // eslint-disable-line max-len, no-console
+            console.log('Pass it withing an object as the second parameter of the withFetchingOnMount call like: `withFetchingOnMount(actionCreator, { dataSelector, loadingSelector })`'); // eslint-disable-line max-len, no-console
         }
     }
 
-    if (!selectors.loading) {
+    if (!loadingSelector) {
         console.error(`withFetchingOnMount(${BaseComponent.displayName}) requires the loading selector, which retrieve the loading status from state.`); // eslint-disable-line max-len, no-console
         if (process.env.NODE_ENV !== 'production') {
-            console.log('Pass it withing an object as the second parameter of the withFetchingOnMount call like: `withFetchingOnMount(actionCreator, { data: dataSelector, loading: loadingSelector })`'); // eslint-disable-line max-len, no-console
+            console.log('Pass it withing an object as the second parameter of the withFetchingOnMount call like: `withFetchingOnMount(actionCreator, { dataSelector, loadingSelector })`'); // eslint-disable-line max-len, no-console
         }
     }
 
@@ -64,9 +66,9 @@ export default (actionCreator, selectors: {}, LoadingComponent = DefaultLoading)
     const factory = createEagerFactory(BaseComponent);
 
     const mapStateToProps = (state, ownProps) => ({
-        data: selectors.data(state, ownProps),
-        loading: selectors.loading(state, ownProps),
-        params: selectors.params && selectors.params(state, ownProps),
+        data: dataSelector && dataSelector(state, ownProps),
+        loading: dataSelector && loadingSelector(state, ownProps),
+        params: paramsSelector && paramsSelector(state, ownProps),
     });
 
     const mapDispatchToProps = dispatch => bindActionCreators({

--- a/src/common-client/fetch/withFetchingOnMount.js
+++ b/src/common-client/fetch/withFetchingOnMount.js
@@ -32,48 +32,48 @@ export const DefaultLoading = () => (
  * This HOC can be used when a component needs to fetch data on mount.
  *
  * @param actionCreator An action creator
- * @param {dataSelector} dataSelector A selector to retrieve the fetched data from state.
- * @param {paramsSelector} paramsSelector A selector to retrieve the parameters to use for fetch, from state.
- * @param {loadingSelector} loadingSelector A selector to retrieve the loading status from state.
+ * @param {Object} selectors The selectors used for data, loading and fetch parameters retrieval from state.
+ * @param {dataSelector} selectors.data Mandatory selector to retrieve the fetched data from state.
+ * @param {loadingSelector} selectors.loading Mandatory selector to retrieve the loading status from state.
+ * @param {paramsSelector} selectors.params Optional selector to retrieve the parameters to use for fetch, from state.
  * @param {Object} LoadingComponent The component to display when loading.
  */
-export default (actionCreator, dataSelector, paramsSelector, loadingSelector, LoadingComponent = DefaultLoading) => // eslint-disable-line max-len
-    BaseComponent => {
-        // This will return the component correctly initialized
-        const factory = createEagerFactory(BaseComponent);
+export default (actionCreator, selectors: {}, LoadingComponent = DefaultLoading) => BaseComponent => {
+    // This will return the component correctly initialized
+    const factory = createEagerFactory(BaseComponent);
 
-        const mapStateToProps = (state, ownProps) => ({
-            data: dataSelector(state, ownProps),
-            loading: loadingSelector(state, ownProps),
-            params: paramsSelector && paramsSelector(state, ownProps),
-        });
+    const mapStateToProps = (state, ownProps) => ({
+        data: selectors.data(state, ownProps),
+        loading: selectors.loading(state, ownProps),
+        params: selectors.params && selectors.params(state, ownProps),
+    });
 
-        const mapDispatchToProps = dispatch => bindActionCreators({
-            action: actionCreator,
-        }, dispatch);
+    const mapDispatchToProps = dispatch => bindActionCreators({
+        action: actionCreator,
+    }, dispatch);
 
-        class WithActionOnMount extends Component {
-            componentDidMount() {
-                this.props.action(this.props.params);
-            }
-
-            render() {
-                const { loading, data, ...props } = this.props;
-
-                if (loading || !data) {
-                    return <LoadingComponent />;
-                }
-
-                return factory(props);
-            }
+    class WithActionOnMount extends Component {
+        componentDidMount() {
+            this.props.action(this.props.params);
         }
 
-        WithActionOnMount.propTypes = {
-            action: PropTypes.func.isRequired,
-            data: PropTypes.any,
-            params: PropTypes.any,
-            loading: PropTypes.bool.isRequired,
-        };
+        render() {
+            const { loading, data, ...props } = this.props;
 
-        return connect(mapStateToProps, mapDispatchToProps)(WithActionOnMount);
+            if (loading || !data) {
+                return <LoadingComponent />;
+            }
+
+            return factory(props);
+        }
+    }
+
+    WithActionOnMount.propTypes = {
+        action: PropTypes.func.isRequired,
+        data: PropTypes.any,
+        params: PropTypes.any,
+        loading: PropTypes.bool.isRequired,
     };
+
+    return connect(mapStateToProps, mapDispatchToProps)(WithActionOnMount);
+};

--- a/src/common-client/fetch/withFetchingOnMount.js
+++ b/src/common-client/fetch/withFetchingOnMount.js
@@ -39,6 +39,27 @@ export const DefaultLoading = () => (
  * @param {Object} LoadingComponent The component to display when loading.
  */
 export default (actionCreator, selectors: {}, LoadingComponent = DefaultLoading) => BaseComponent => {
+    if (!selectors) {
+        console.error(`withFetchingOnMount(${BaseComponent.displayName}) requires at least two selectors, one to retrieve the fetched data and the other to retrieve the loading state.`); // eslint-disable-line max-len, no-console
+        if (process.env.NODE_ENV !== 'production') {
+            console.log('Pass them withing an object as the second parameter of the withFetchingOnMount call like: `withFetchingOnMount(actionCreator, { data: dataSelector, loading: loadingSelector })`'); // eslint-disable-line max-len, no-console
+        }
+    }
+
+    if (!selectors.data) {
+        console.error(`withFetchingOnMount(${BaseComponent.displayName}) requires the data selector, which retrieve the fetched data from state.`); // eslint-disable-line max-len, no-console
+        if (process.env.NODE_ENV !== 'production') {
+            console.log('Pass it withing an object as the second parameter of the withFetchingOnMount call like: `withFetchingOnMount(actionCreator, { data: dataSelector, loading: loadingSelector })`'); // eslint-disable-line max-len, no-console
+        }
+    }
+
+    if (!selectors.loading) {
+        console.error(`withFetchingOnMount(${BaseComponent.displayName}) requires the loading selector, which retrieve the loading status from state.`); // eslint-disable-line max-len, no-console
+        if (process.env.NODE_ENV !== 'production') {
+            console.log('Pass it withing an object as the second parameter of the withFetchingOnMount call like: `withFetchingOnMount(actionCreator, { data: dataSelector, loading: loadingSelector })`'); // eslint-disable-line max-len, no-console
+        }
+    }
+
     // This will return the component correctly initialized
     const factory = createEagerFactory(BaseComponent);
 

--- a/src/frontend/js/order/OrderDetails.js
+++ b/src/frontend/js/order/OrderDetails.js
@@ -54,11 +54,7 @@ const titleSelector = (state, ownProps) => {
 };
 
 export default compose(
-    withFetchingOnMount(orderActions.item.request, {
-        data: dataSelector,
-        params: paramsSelector,
-        loading: loadingSelector,
-    }),
+    withFetchingOnMount(orderActions.item.request, { dataSelector, paramsSelector, loadingSelector }),
     withWindowTitle(titleSelector),
     connect(mapStateToProps),
 )(OrderDetails);

--- a/src/frontend/js/order/OrderDetails.js
+++ b/src/frontend/js/order/OrderDetails.js
@@ -54,7 +54,11 @@ const titleSelector = (state, ownProps) => {
 };
 
 export default compose(
-    withFetchingOnMount(orderActions.item.request, dataSelector, paramsSelector, loadingSelector),
+    withFetchingOnMount(orderActions.item.request, {
+        data: dataSelector,
+        params: paramsSelector,
+        loading: loadingSelector,
+    }),
     withWindowTitle(titleSelector),
     connect(mapStateToProps),
 )(OrderDetails);

--- a/src/frontend/js/order/OrderList.js
+++ b/src/frontend/js/order/OrderList.js
@@ -28,6 +28,9 @@ const mapStateToProps = state => ({ orders: state.order.list });
 
 export default compose(
     withWindowTitle('Orders'),
-    withFetchingOnMount(orderActions.list.request, dataSelector, null, loadingSelector),
+    withFetchingOnMount(orderActions.list.request, {
+        data: dataSelector,
+        loading: loadingSelector,
+    }),
     connect(mapStateToProps)
 )(OrderList);

--- a/src/frontend/js/order/OrderList.js
+++ b/src/frontend/js/order/OrderList.js
@@ -28,9 +28,6 @@ const mapStateToProps = state => ({ orders: state.order.list });
 
 export default compose(
     withWindowTitle('Orders'),
-    withFetchingOnMount(orderActions.list.request, {
-        data: dataSelector,
-        loading: loadingSelector,
-    }),
+    withFetchingOnMount(orderActions.list.request, { dataSelector, loadingSelector }),
     connect(mapStateToProps)
 )(OrderList);

--- a/src/frontend/js/product/ProductDetails.js
+++ b/src/frontend/js/product/ProductDetails.js
@@ -76,7 +76,11 @@ const titleSelector = (state, ownProps) => {
 };
 
 export default compose(
-    withFetchingOnMount(productActions.item.request, dataSelector, paramsSelector, loadingSelector),
+    withFetchingOnMount(productActions.item.request, {
+        data: dataSelector,
+        params: paramsSelector,
+        loading: loadingSelector,
+    }),
     withWindowTitle(titleSelector),
     connect(mapStateToProps, mapDispatchToProps),
 )(ProductDetails);

--- a/src/frontend/js/product/ProductDetails.js
+++ b/src/frontend/js/product/ProductDetails.js
@@ -76,11 +76,7 @@ const titleSelector = (state, ownProps) => {
 };
 
 export default compose(
-    withFetchingOnMount(productActions.item.request, {
-        data: dataSelector,
-        params: paramsSelector,
-        loading: loadingSelector,
-    }),
+    withFetchingOnMount(productActions.item.request, { dataSelector, paramsSelector, loadingSelector }),
     withWindowTitle(titleSelector),
     connect(mapStateToProps, mapDispatchToProps),
 )(ProductDetails);

--- a/src/frontend/js/product/ProductList.js
+++ b/src/frontend/js/product/ProductList.js
@@ -36,6 +36,9 @@ const mapDispatchToProps = ({
 
 export default compose(
     withWindowTitle('Products'),
-    withFetchingOnMount(productActions.list.request, dataSelector, null, loadingSelector),
+    withFetchingOnMount(productActions.list.request, {
+        data: dataSelector,
+        loading: loadingSelector,
+    }),
     connect(mapStateToProps, mapDispatchToProps)
 )(ProductList);

--- a/src/frontend/js/product/ProductList.js
+++ b/src/frontend/js/product/ProductList.js
@@ -36,9 +36,6 @@ const mapDispatchToProps = ({
 
 export default compose(
     withWindowTitle('Products'),
-    withFetchingOnMount(productActions.list.request, {
-        data: dataSelector,
-        loading: loadingSelector,
-    }),
+    withFetchingOnMount(productActions.list.request, { dataSelector, loadingSelector }),
     connect(mapStateToProps, mapDispatchToProps)
 )(ProductList);


### PR DESCRIPTION
Follow #116 

## old signature
```js
withFetchingOnMount(actionCreator, dataSelector, paramsSelector, loadingSelector, LoadingComponent)
```

With `actionCreator`, `dataSelector` and `loadingSelector` mandatory.

*drawback*: when paramsSelector is not needed, one has to pass `null` as the third parameter.

## proposed signature

```js
withFetchingOnMount(actionCreator, { dataSelector, loadingSelector, paramsSelector }, LoadingComponent)
```

With `actionCreator`, `selectors.dataSelector` and `selectors.loadingSelector` mandatory.
