### PR TITLE
[RFR] Fixed e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "dependencies": {
     "admin-on-rest": "0.4.0",
-    "async-to-gen": "1.1.4",
+    "async-to-gen": "1.3.0",
     "bcrypt": "0.8.7",
     "bootstrap": "4.0.0-alpha.5",
     "classnames": "2.2.5",
@@ -58,7 +58,7 @@
     "redux-form-schema": "0.0.3",
     "redux-saga": "0.12.0",
     "redux-thunk": "2.1.0",
-    "reify": "0.3.8",
+    "reify": "0.4.4",
     "request": "2.76.0",
     "tether": "1.3.7",
     "thunkify": "2.1.2",

--- a/src/api/e2e/public/api.js
+++ b/src/api/e2e/public/api.js
@@ -5,8 +5,8 @@ import request from '../../../common/e2e/lib/request';
 
 describe('/api', () => {
     describe('GET', () => {
-        it('should not require authentification', function* () {
-            const { statusCode, body } = yield request({
+        it('should not require authentification', async () => {
+            const { statusCode, body } = await request({
                 method: 'GET',
                 url: '/api',
             });
@@ -15,8 +15,8 @@ describe('/api', () => {
     });
 
     describe('POST', () => {
-        it('should not allow POST request', function* () {
-            const { statusCode, body } = yield request({
+        it('should not allow POST request', async () => {
+            const { statusCode, body } = await request({
                 method: 'POST',
                 url: '/api',
             });
@@ -25,8 +25,8 @@ describe('/api', () => {
     });
 
     describe('PUT', () => {
-        it('should not allow PUT request', function* () {
-            const { statusCode, body } = yield request({
+        it('should not allow PUT request', async () => {
+            const { statusCode, body } = await request({
                 method: 'PUT',
                 url: '/api',
             });
@@ -35,8 +35,8 @@ describe('/api', () => {
     });
 
     describe('DELETE', () => {
-        it('should not allow DELETE request', function* () {
-            const { statusCode, body } = yield request({
+        it('should not allow DELETE request', async () => {
+            const { statusCode, body } = await request({
                 method: 'DELETE',
                 url: '/api',
             });

--- a/src/api/e2e/public/apiAuthenticate.js
+++ b/src/api/e2e/public/apiAuthenticate.js
@@ -11,17 +11,17 @@ describe('/api/sign-in', () => {
     let db;
     let pool;
 
-    before(function* addFixtures() {
+    before(async () => {
         pool = new PgPool(config.apps.api.db);
-        db = yield pool.connect();
+        db = await pool.connect();
         fixtureLoader = fixturesFactory(db);
 
-        yield fixtureLoader.loadDefaultFixtures();
+        await fixtureLoader.loadDefaultFixtures();
     });
 
     describe('GET', () => {
-        it('should not allow GET request', function* () {
-            const { statusCode, body } = yield request({
+        it('should not allow GET request', async () => {
+            const { statusCode, body } = await request({
                 method: 'PUT',
                 url: '/api/sign-in',
             });
@@ -30,8 +30,8 @@ describe('/api/sign-in', () => {
     });
 
     describe('POST', () => {
-        it('should return 401 with an empty email and password', function* () {
-            const { statusCode, body } = yield request({
+        it('should return 401 with an empty email and password', async () => {
+            const { statusCode, body } = await request({
                 method: 'POST',
                 url: '/api/sign-in',
                 body: {
@@ -41,8 +41,8 @@ describe('/api/sign-in', () => {
             });
             expect(statusCode).toEqual(401, JSON.stringify(body));
         });
-        it('should return 401 with an empty email', function* () {
-            const { statusCode, body } = yield request({
+        it('should return 401 with an empty email', async () => {
+            const { statusCode, body } = await request({
                 method: 'POST',
                 url: '/api/sign-in',
                 body: {
@@ -52,8 +52,8 @@ describe('/api/sign-in', () => {
             });
             expect(statusCode).toEqual(401, JSON.stringify(body));
         });
-        it('should return 401 with an empty password', function* () {
-            const { statusCode, body } = yield request({
+        it('should return 401 with an empty password', async () => {
+            const { statusCode, body } = await request({
                 method: 'POST',
                 url: '/api/sign-in',
                 body: {
@@ -63,8 +63,8 @@ describe('/api/sign-in', () => {
             });
             expect(statusCode).toEqual(401, JSON.stringify(body));
         });
-        it('should return 401 with a wrong email', function* () {
-            const { statusCode, body } = yield request({
+        it('should return 401 with a wrong email', async () => {
+            const { statusCode, body } = await request({
                 method: 'POST',
                 url: '/api/sign-in',
                 body: {
@@ -74,8 +74,8 @@ describe('/api/sign-in', () => {
             });
             expect(statusCode).toEqual(401, JSON.stringify(body));
         });
-        it('should return 401 with a wrong password', function* () {
-            const { statusCode, body } = yield request({
+        it('should return 401 with a wrong password', async () => {
+            const { statusCode, body } = await request({
                 method: 'POST',
                 url: '/api/sign-in',
                 body: {
@@ -85,8 +85,8 @@ describe('/api/sign-in', () => {
             });
             expect(statusCode).toEqual(401, JSON.stringify(body));
         });
-        it('should return 200 with a valid email and password', function* () {
-            const { statusCode, body } = yield request({
+        it('should return 200 with a valid email and password', async () => {
+            const { statusCode, body } = await request({
                 method: 'POST',
                 url: '/api/sign-in',
                 body: {
@@ -98,8 +98,8 @@ describe('/api/sign-in', () => {
         });
     });
     describe('PUT', () => {
-        it('should not allow PUT request', function* () {
-            const { statusCode, body } = yield request({
+        it('should not allow PUT request', async () => {
+            const { statusCode, body } = await request({
                 method: 'PUT',
                 url: '/api/sign-in',
             });
@@ -107,8 +107,8 @@ describe('/api/sign-in', () => {
         });
     });
     describe('DELETE', () => {
-        it('should not allow DELETE request', function* () {
-            const { statusCode, body } = yield request({
+        it('should not allow DELETE request', async () => {
+            const { statusCode, body } = await request({
                 method: 'DELETE',
                 url: '/api/sign-in',
             });
@@ -116,8 +116,8 @@ describe('/api/sign-in', () => {
         });
     });
 
-    after(function* clearFixtures() {
-        yield fixtureLoader.removeAllFixtures();
+    after(async () => {
+        await fixtureLoader.removeAllFixtures();
         db.release();
         pool.end();
     });

--- a/src/api/e2e/public/apiOrders.js
+++ b/src/api/e2e/public/apiOrders.js
@@ -16,17 +16,17 @@ describe('/api/orders', () => {
     let db;
     let pool;
 
-    before(function* addFixtures() {
+    before(async () => {
         pool = new PgPool(config.apps.api.db);
-        db = yield pool.connect();
+        db = await pool.connect();
         fixtureLoader = fixturesFactory(db);
 
-        yield fixtureLoader.loadDefaultFixtures();
+        await fixtureLoader.loadDefaultFixtures();
         const userRepository = userFactory(db);
-        user = yield userRepository.findByEmail('user1@marmelab.io');
-        userToken = yield fixtureLoader.getTokenFor('user1@marmelab.io');
-        userCookieToken = yield fixtureLoader.getCookieTokenFor('user1@marmelab.io');
-        yield orderFactory(db).insertOne({
+        user = await userRepository.findByEmail('user1@marmelab.io');
+        userToken = await fixtureLoader.getTokenFor('user1@marmelab.io');
+        userCookieToken = await fixtureLoader.getCookieTokenFor('user1@marmelab.io');
+        await orderFactory(db).insertOne({
             reference: 'ref1',
             date: new Date(),
             customer_id: user.id,
@@ -37,32 +37,32 @@ describe('/api/orders', () => {
     });
 
     describe('GET', () => {
-        it('should require authentification', function* () {
-            const { statusCode, body } = yield request({
+        it('should require authentification', async () => {
+            const { statusCode, body } = await request({
                 method: 'GET',
                 url: '/api/orders',
             });
             expect(statusCode).toEqual(401, JSON.stringify(body));
         });
 
-        it('should require authentification without cookie token', function* () {
-            const { statusCode, body } = yield request({
+        it('should require authentification without cookie token', async () => {
+            const { statusCode, body } = await request({
                 method: 'GET',
                 url: '/api/orders',
             }, userToken);
             expect(statusCode).toEqual(401, JSON.stringify(body));
         });
 
-        it('should require authentification with only cookie token', function* () {
-            const { statusCode, body } = yield request({
+        it('should require authentification with only cookie token', async () => {
+            const { statusCode, body } = await request({
                 method: 'GET',
                 url: '/api/orders',
             }, null, { token: userCookieToken });
             expect(statusCode).toEqual(401, JSON.stringify(body));
         });
 
-        it('should return all connected user\'s orders', function* () {
-            const { statusCode, body } = yield request({
+        it('should return all connected user\'s orders', async () => {
+            const { statusCode, body } = await request({
                 url: '/api/orders',
             }, userToken, { token: userCookieToken });
 
@@ -81,8 +81,8 @@ describe('/api/orders', () => {
     });
 
     describe('POST', () => {
-        it('should require authentification', function* () {
-            const { statusCode, body } = yield request({
+        it('should require authentification', async () => {
+            const { statusCode, body } = await request({
                 method: 'POST',
                 url: '/api/orders',
                 body: {
@@ -94,8 +94,8 @@ describe('/api/orders', () => {
             expect(statusCode).toEqual(401, JSON.stringify(body));
         });
 
-        it('should require authentification without cookie token', function* () {
-            const { statusCode, body } = yield request({
+        it('should require authentification without cookie token', async () => {
+            const { statusCode, body } = await request({
                 method: 'POST',
                 url: '/api/orders',
                 body: {
@@ -106,8 +106,8 @@ describe('/api/orders', () => {
             expect(statusCode).toEqual(401, JSON.stringify(body));
         });
 
-        it('should require authentification with only cookie token', function* () {
-            const { statusCode, body } = yield request({
+        it('should require authentification with only cookie token', async () => {
+            const { statusCode, body } = await request({
                 method: 'POST',
                 url: '/api/orders',
                 body: {
@@ -118,10 +118,10 @@ describe('/api/orders', () => {
             expect(statusCode).toEqual(401, JSON.stringify(body));
         });
 
-        it('should create a order', function* () {
-            let userOrders = yield orderFactory(db).selectByUserId(user.id);
+        it('should create a order', async () => {
+            let userOrders = await orderFactory(db).selectByUserId(user.id);
             expect(userOrders.length).toEqual(1);
-            const { statusCode, body } = yield request({
+            const { statusCode, body } = await request({
                 method: 'POST',
                 url: '/api/orders',
                 body: {
@@ -131,14 +131,14 @@ describe('/api/orders', () => {
                 },
             }, userToken, { token: userCookieToken });
             expect(statusCode).toEqual(200, JSON.stringify(body));
-            userOrders = yield orderFactory(db).selectByUserId(user.id);
+            userOrders = await orderFactory(db).selectByUserId(user.id);
             expect(userOrders.length).toEqual(2);
         });
     });
 
     describe('PUT', () => {
-        it('should not allow PUT request', function* () {
-            const { statusCode, body } = yield request({
+        it('should not allow PUT request', async () => {
+            const { statusCode, body } = await request({
                 method: 'PUT',
                 url: '/api/orders',
             });
@@ -146,8 +146,8 @@ describe('/api/orders', () => {
         });
     });
 
-    after(function* removeFixtures() {
-        yield fixtureLoader.removeAllFixtures();
+    after(async () => {
+        await fixtureLoader.removeAllFixtures();
         db.release();
         pool.end();
     });

--- a/src/api/e2e/public/apiProducts.js
+++ b/src/api/e2e/public/apiProducts.js
@@ -12,24 +12,24 @@ describe('/api/products', () => {
         let db;
         let pool;
 
-        before(function* addFixtures() {
+        before(async () => {
             pool = new PgPool(config.apps.api.db);
-            db = yield pool.connect();
+            db = await pool.connect();
             fixtureLoader = fixturesFactory(db);
 
-            yield fixtureLoader.loadDefaultFixtures();
+            await fixtureLoader.loadDefaultFixtures();
         });
 
-        it('should not require authentification', function* () {
-            const { statusCode, body } = yield request({
+        it('should not require authentification', async () => {
+            const { statusCode, body } = await request({
                 method: 'GET',
                 url: '/api/products',
             });
             expect(statusCode).toEqual(200, JSON.stringify(body));
         });
 
-        it('should return a list of all products', function* () {
-            const { body } = yield request({
+        it('should return a list of all products', async () => {
+            const { body } = await request({
                 method: 'GET',
                 url: '/api/products',
             });
@@ -76,16 +76,16 @@ describe('/api/products', () => {
             ]);
         });
 
-        after(function* removeFixtures() {
-            yield fixtureLoader.removeAllFixtures();
+        after(async () => {
+            await fixtureLoader.removeAllFixtures();
             db.release();
             pool.end();
         });
     });
 
     describe('POST', () => {
-        it('should not allow POST request', function* () {
-            const { body, statusCode } = yield request({
+        it('should not allow POST request', async () => {
+            const { body, statusCode } = await request({
                 method: 'POST',
                 url: '/api/products',
             });
@@ -94,8 +94,8 @@ describe('/api/products', () => {
     });
 
     describe('PUT', () => {
-        it('should not allow PUT request', function* () {
-            const { body, statusCode } = yield request({
+        it('should not allow PUT request', async () => {
+            const { body, statusCode } = await request({
                 method: 'PUT',
                 url: '/api/products',
             });
@@ -104,8 +104,8 @@ describe('/api/products', () => {
     });
 
     describe('DELETE', () => {
-        it('should not allow DELETE request', function* () {
-            const { body, statusCode } = yield request({
+        it('should not allow DELETE request', async () => {
+            const { body, statusCode } = await request({
                 method: 'DELETE',
                 url: '/api/products',
             });

--- a/src/api/e2e/public/apiProductsId.js
+++ b/src/api/e2e/public/apiProductsId.js
@@ -12,24 +12,24 @@ describe('/api/products/{id}', () => {
     let pool;
     let product;
 
-    before(function* addFixtures() {
+    before(async () => {
         pool = new PgPool(config.apps.api.db);
-        db = yield pool.connect();
+        db = await pool.connect();
         fixtureLoader = fixturesFactory(db);
-        product = yield fixtureLoader.addProduct();
+        product = await fixtureLoader.addProduct();
     });
 
     describe('GET', () => {
-        it('should not require authentification', function* () {
-            const { statusCode, body } = yield request({
+        it('should not require authentification', async () => {
+            const { statusCode, body } = await request({
                 method: 'GET',
                 url: `/api/products/${product.id}`,
             });
             expect(statusCode).toEqual(200, JSON.stringify(body));
         });
 
-        it('should return information about a specific product', function* () {
-            const { body } = yield request({
+        it('should return information about a specific product', async () => {
+            const { body } = await request({
                 method: 'GET',
                 url: `/api/products/${product.id}`,
             });
@@ -41,8 +41,8 @@ describe('/api/products/{id}', () => {
     });
 
     describe('POST', () => {
-        it('should not allow POST request', function* () {
-            const { body, statusCode } = yield request({
+        it('should not allow POST request', async () => {
+            const { body, statusCode } = await request({
                 method: 'POST',
                 url: `/api/products/${product.id}`,
             });
@@ -51,8 +51,8 @@ describe('/api/products/{id}', () => {
     });
 
     describe('PUT', () => {
-        it('should not allow PUT request', function* () {
-            const { body, statusCode } = yield request({
+        it('should not allow PUT request', async () => {
+            const { body, statusCode } = await request({
                 method: 'PUT',
                 url: `/api/products/${product.id}`,
             });
@@ -61,16 +61,16 @@ describe('/api/products/{id}', () => {
     });
 
     describe('DELETE', () => {
-        it('should not allow DELETE request', function* () {
-            const { body, statusCode } = yield request({
+        it('should not allow DELETE request', async () => {
+            const { body, statusCode } = await request({
                 method: 'DELETE',
                 url: `/api/products/${product.id}`,
             });
             expect(statusCode).toEqual(405, JSON.stringify(body));
         });
     });
-    after(function* removeFixtures() {
-        yield fixtureLoader.removeAllFixtures();
+    after(async () => {
+        await fixtureLoader.removeAllFixtures();
         db.release();
         pool.end();
     });

--- a/src/api/e2e/public/healthcare.js
+++ b/src/api/e2e/public/healthcare.js
@@ -5,8 +5,8 @@ import request from '../../../common/e2e/lib/request';
 
 describe('/healthcare', () => {
     describe('GET', () => {
-        it('should return an object describing the API health', function* () {
-            const { statusCode, body } = yield request({
+        it('should return an object describing the API health', async () => {
+            const { statusCode, body } = await request({
                 method: 'GET',
                 url: '/healthcare',
             });

--- a/src/common/e2e/lib/fixturesLoader.js
+++ b/src/common/e2e/lib/fixturesLoader.js
@@ -12,34 +12,34 @@ export default function (client) {
     const productQueries = productFactory(client);
     const userQueries = userFactory(client);
 
-    function* loadDefaultFixtures() {
-        yield productQueries.batchInsert(data.products);
-        yield userQueries.batchInsert(data.users);
+    async function loadDefaultFixtures() {
+        await productQueries.batchInsert(data.products);
+        await userQueries.batchInsert(data.users);
     }
 
-    function* removeAllFixtures() {
-        yield client.query({ sql: 'TRUNCATE product RESTART IDENTITY' });
-        yield client.query({ sql: 'TRUNCATE user_order RESTART IDENTITY' });
-        yield client.query({ sql: 'TRUNCATE user_account RESTART IDENTITY' });
+    async function removeAllFixtures() {
+        await client.query({ sql: 'TRUNCATE product RESTART IDENTITY' });
+        await client.query({ sql: 'TRUNCATE user_order RESTART IDENTITY' });
+        await client.query({ sql: 'TRUNCATE user_account RESTART IDENTITY' });
     }
 
-    function* getTokenFor(email) {
+    async function getTokenFor(email) {
         // const causes an error! don't know why
-        const user = yield userQueries.findByEmail(email);
-        delete user.id;
+        const user = await userQueries.findByEmail(email);
+        delete user.password;
 
         return jwt.sign(user, config.apps.api.security.jwt.privateKey);
     }
 
-    function* getCookieTokenFor(email) {
-        const token = yield getTokenFor(email);
+    async function getCookieTokenFor(email) {
+        const token = await getTokenFor(email);
 
         return crypto.createHmac('sha256', config.apps.api.security.secret)
             .update(token)
             .digest('hex');
     }
 
-    function* addProduct(productData) {
+    async function addProduct(productData) {
         // const causes an error! don't know why
         const defaultProductData = {
             reference: uuid.v1(),
@@ -53,7 +53,7 @@ export default function (client) {
         };
 
         // ES7, in Babel it is experimental stage 2 and enabled by default
-        return yield productQueries.insertOne(Object.assign({}, defaultProductData, productData));
+        return await productQueries.insertOne(Object.assign({}, defaultProductData, productData));
     }
 
     return {

--- a/src/common/e2e/lib/request.js
+++ b/src/common/e2e/lib/request.js
@@ -3,7 +3,7 @@ import request from 'request';
 import app from '../../../api';
 
 export default function myRequest(params, authToken = null, cookies = {}) {
-    return (callback) => {
+    return new Promise((resolve, reject) => {
         const port = process.env.NODE_PORT || 3010;
         const portOrigin = process.env.NODE_PORT_ORIGIN || 8081;
         const baseUrl = `http://localhost:${port}`;
@@ -29,7 +29,9 @@ export default function myRequest(params, authToken = null, cookies = {}) {
         baseRequest(params, (error, response) => {
             server.close();
 
-            callback(error, response);
+            if (error) return reject(error);
+
+            return resolve(response);
         });
-    };
+    });
 }


### PR DESCRIPTION
e2e tests were not running as they were using generators and `co-mocha` has been removed from dependencies.

They therefore have been converted to use the async/await syntax which is supported by mocha.